### PR TITLE
set relationship and bump versions to mark as support version 13

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,8 +6,8 @@
   "library": "false",
   "compatibility": {
     "minimum": 10,
-    "verified": 11,
-    "maximum": 11
+    "verified": 13,
+    "maximum": 13
   },
   "authors": [
     {
@@ -127,5 +127,15 @@
    "url":"https://github.com/SeaSaltSong/wod20-compendium",
    "manifest":"https://raw.githubusercontent.com/SeaSaltSong/wod20-compendium/main/module.json",
    "download":"https://github.com/SeaSaltSong/wod20-compendium/releases/download/v1.0.3-HOTFIX/module.zip",
-   "bugs":"https://github.com/pcdoyle/wod20-compendium/issues"
+   "bugs":"https://github.com/pcdoyle/wod20-compendium/issues",
+   "relationships": {
+    "systems": [
+      {
+        "id": "worldofdarkness",
+        "type": "system",
+        "compatibility": {}
+      }
+    ]
+  },
+  "flags": {}
 }


### PR DESCRIPTION
This seems to make it work properly in version 13 of foundry

EDIT: It does however not fix importing things into folders but the import itself works